### PR TITLE
Revert "using ListenableBuilder to make the code read cleaner"

### DIFF
--- a/lib/screens/landmark_detail.dart
+++ b/lib/screens/landmark_detail.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:landmarks_flutter/models/landmark.dart';
 import 'package:landmarks_flutter/views/star_button.dart';
-import 'package:listenable_builder/listenable_builder.dart';
 
 class LandmarkDetail extends StatelessWidget {
   final Landmark landmark;
@@ -55,8 +54,8 @@ class LandmarkDetail extends StatelessWidget {
                       Padding(padding: EdgeInsets.only(top: 12.0)),
                       Padding(
                         padding: const EdgeInsets.only(left: 5.0),
-                        child: ListenableBuilder(
-                          listenable: landmark,
+                        child: AnimatedBuilder(
+                          animation: landmark,
                           builder: (context, widget) {
                             return StarButton(
                               isFavorite: landmark.isFavorite,

--- a/lib/views/landmark_cell.dart
+++ b/lib/views/landmark_cell.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:landmarks_flutter/common/constants.dart';
 import 'package:landmarks_flutter/models/landmark.dart';
 import 'package:landmarks_flutter/views/star_button.dart';
-import 'package:listenable_builder/listenable_builder.dart';
 
 class LandmarkCell extends StatelessWidget {
   final Landmark landmark;
@@ -33,8 +32,8 @@ class LandmarkCell extends StatelessWidget {
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                ListenableBuilder(
-                  listenable: landmark,
+                AnimatedBuilder(
+                  animation: landmark,
                   builder: (context, widget) {
                     return landmark.isFavorite ? StarButton(isFavorite: landmark.isFavorite) : Container();
                   },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,13 +53,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.15+1"
-  listenable_builder:
-    dependency: "direct main"
-    description:
-      name: listenable_builder
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   matcher:
     dependency: transitive
     description:
@@ -94,7 +87,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
 
   cupertino_icons: ^0.1.2
   google_maps_flutter: ^0.5.15+1
-  listenable_builder: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I appreciate the effort to make this semantic improvement, but we should avoid external dependencies to this project whenever possible.