### PR TITLE
Main: Initialize WidgetsBinding before running the app.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:landmarks_flutter/views/landmark_cell.dart';
 import 'package:landmarks_flutter/models/data.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   loadData().then((_) {
     runApp(MyApp());
   });


### PR DESCRIPTION
This PR ensures a `WidgetsBinding` instance is initialized before running the app.

If this instance is not initialized before our `loadData()` call, the app will fail to compile with an unhandled exception: "ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized." 

**Testing Instructions**
* Check out this repo and attempt to start the app.
* Notice it will fail to start, breaking on the unhandled exception given above.
* Switch to this PR.
* Restart the app, and verify it loads correctly.